### PR TITLE
Bump sea-orm version to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sea-orm-adapter"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["zihan <ZihanType@proton.me>"]
 license = "MIT/Apache-2.0"
@@ -15,7 +15,7 @@ include = ["src/**/*", "Cargo.toml"]
 [dependencies]
 async-trait = { version = "0.1", default-features = false }
 casbin = { version = "2", default-features = false }
-sea-orm = { version = "0.12", default-features = false, features = ["macros"] }
+sea-orm = { version = "1.0.0", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["full"] }


### PR DESCRIPTION
Build OK

Test Failed, but it failed before the change as well, due to the fact that the databases specified in adapter.rs test_adapter are not present in the repository.